### PR TITLE
Repair cm.bell-labs.com links

### DIFF
--- a/02/unix.tex
+++ b/02/unix.tex
@@ -1361,8 +1361,8 @@ System}, on the Internet at
 \bibitem{history:dmr-history}Dennis M. Ritchie, 'The Evolution of the Unix
 Time-sharing System', published in {\em AT\&T Bell Laboratories Technical
 Journal}, ``Computing Science and Systems: The UNIX System,'' 63 No. 6
-Part 2, October 1984;  also available via the Internet Archive at e.g.
-\url{https://web.archive.org/web/20150408054606/http://cm.bell-labs.com/cm/cs/who/dmr/hist.html} (visited January 17, 2017)
+Part 2, October 1984;  on the Internet at
+\url{https://www.bell-labs.com/usr/dmr/www/hist.html} (visited January 17, 2017)
 
 \bibitem{history:kernighan-pike-upe}Brian W. Kernighan, Rob Pike, {\em The UNIX
 Programming Environment}, Prentice Hall, 1984
@@ -1382,17 +1382,16 @@ Pan Books, 1979
 Language}, Prentice Hall, 1988
 
 \bibitem{history:dmr-pipes}Dennis M. Ritchie, 'Advice
-from Doug Mcilroy'; now only found on the Internet
-Archive at
-\url{https://web.archive.org/web/20150205024833/http://cm.bell-labs.com/cm/cs/who/dmr/mdmpipe.html}
+from Doug Mcilroy'; on the Internet at
+\url{https://www.bell-labs.com/usr/dmr/www/mdmpipe.html}
 
 \bibitem{history:mcilroy-reader}Douglas McIlroy, {\em
 A Research UNIX Reader: Annotated Excerpts from the
 Programmer's Manual, 1971-1986}; on the Internet at
 \url{http://www.cs.dartmouth.edu/~doug/reader.pdf}
 
-\bibitem{history:bsdisuit}'USL vs. BSDI documents', only available on the Internet Archive via e.g.
-\url{https://web.archive.org/web/20150205025251/http://cm.bell-labs.com/cm/cs/who/dmr/bsdi/bsdisuit.html} (visited January
+\bibitem{history:bsdisuit}'USL vs. BSDI documents', on the Internet at
+\url{https://www.bell-labs.com/usr/dmr/www/bsdi/bsdisuit.html} (visited January
 18, 2017)
 
 \bibitem{history:torvalds-announce}'What would you like to see most in minix?',

--- a/05/software-installation-and-package-management.tex
+++ b/05/software-installation-and-package-management.tex
@@ -2286,7 +2286,7 @@ Prentice Hall, 2010
 \bibitem{thompson:trust}Ken Thompson {\em Reflections on Trusting Trust},
 Communication of the ACM, Vol. 27, No. 8, August 1984, Association for
 Computing Machinery, Inc.; also available on the Internet at
-{\url http://cm.bell-labs.com/who/ken/trust.html}
+{\url http://cs.bell-labs.co/who/ken/trust.html}
 (visited December 5th, 2012)
 
 \end{thebibliography}


### PR DESCRIPTION
This:

 * fixes the "Reflections on Trusting Trust" link
 * Replaces 2 archive.org links with live links (mdmpipe and "The Evolution of the Unix Time-sharing System")